### PR TITLE
[branch-45] Workaround timestamp types

### DIFF
--- a/datafusion/substrait/src/logical_plan/consumer.rs
+++ b/datafusion/substrait/src/logical_plan/consumer.rs
@@ -2356,27 +2356,8 @@ fn from_substrait_type(
             },
             r#type::Kind::Fp32(_) => Ok(DataType::Float32),
             r#type::Kind::Fp64(_) => Ok(DataType::Float64),
-            r#type::Kind::Timestamp(ts) => {
-                // Kept for backwards compatibility, new plans should use PrecisionTimestamp(Tz) instead
-                #[allow(deprecated)]
-                match ts.type_variation_reference {
-                    TIMESTAMP_SECOND_TYPE_VARIATION_REF => {
-                        Ok(DataType::Timestamp(TimeUnit::Second, None))
-                    }
-                    TIMESTAMP_MILLI_TYPE_VARIATION_REF => {
-                        Ok(DataType::Timestamp(TimeUnit::Millisecond, None))
-                    }
-                    TIMESTAMP_MICRO_TYPE_VARIATION_REF => {
-                        Ok(DataType::Timestamp(TimeUnit::Microsecond, None))
-                    }
-                    TIMESTAMP_NANO_TYPE_VARIATION_REF => {
-                        Ok(DataType::Timestamp(TimeUnit::Nanosecond, None))
-                    }
-                    v => not_impl_err!(
-                        "Unsupported Substrait type variation {v} of type {s_kind:?}"
-                    ),
-                }
-            }
+            // TODO: DataDog-specific workaround, don't commit upstream
+            r#type::Kind::Timestamp(_) => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
             r#type::Kind::PrecisionTimestamp(pts) => {
                 let unit = match pts.precision {
                     0 => Ok(TimeUnit::Second),


### PR DESCRIPTION
This is a change that should not be committed upstream, it's just specific to how we produce substrait plans. Ideally, this is temporary, and once we have better support for precision timestamps, this will not be necessary.