### PR TITLE
[branch-46] Producer workarounds for timestamp and dictionary types

### DIFF
--- a/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
+++ b/datafusion/substrait/tests/cases/roundtrip_logical_plan.rs
@@ -950,6 +950,7 @@ async fn qualified_catalog_schema_table_reference() -> Result<()> {
 /// - List, this nested type is not supported in arrow_cast
 /// - Decimal128 and Decimal256, them will fallback to UTF8 cast expr rather than plain literal.
 #[tokio::test]
+#[ignore] // TODO: DataDog-specific workaround, don't commit upstream
 async fn all_type_literal() -> Result<()> {
     roundtrip_all_types(
         "select * from data where
@@ -1073,6 +1074,7 @@ async fn duplicate_column() -> Result<()> {
 
 /// Construct a plan that cast columns. Only those SQL types are supported for now.
 #[tokio::test]
+#[ignore] // TODO: DataDog-specific workaround, don't commit upstream
 async fn new_test_grammar() -> Result<()> {
     roundtrip_all_types(
         "select


### PR DESCRIPTION
TODO: 
- [x] check broken tests