### PR TITLE
[branch-46] Revert "Bump MSRV to 1.82, toolchain to 1.85 (#14811)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/apache/datafusion"
 # Define Minimum Supported Rust Version (MSRV)
-rust-version = "1.82.0"
+rust-version = "1.81.0"
 # Define DataFusion version
 version = "46.0.0"
 

--- a/datafusion/common/src/table_reference.rs
+++ b/datafusion/common/src/table_reference.rs
@@ -193,7 +193,8 @@ impl TableReference {
         match self {
             TableReference::Bare { table } => **table == *other.table(),
             TableReference::Partial { schema, table } => {
-                **table == *other.table() && other.schema().is_none_or(|s| *s == **schema)
+                **table == *other.table()
+                    && other.schema().map_or(true, |s| *s == **schema)
             }
             TableReference::Full {
                 catalog,
@@ -201,8 +202,8 @@ impl TableReference {
                 table,
             } => {
                 **table == *other.table()
-                    && other.schema().is_none_or(|s| *s == **schema)
-                    && other.catalog().is_none_or(|c| *c == **catalog)
+                    && other.schema().map_or(true, |s| *s == **schema)
+                    && other.catalog().map_or(true, |c| *c == **catalog)
             }
         }
     }

--- a/datafusion/expr/src/utils.rs
+++ b/datafusion/expr/src/utils.rs
@@ -837,7 +837,7 @@ pub fn exprlist_len(
                             .enumerate()
                             .filter_map(|(idx, field)| {
                                 let (maybe_table_ref, _) = schema.qualified_field(idx);
-                                if maybe_table_ref.is_none_or(|q| q == qualifier) {
+                                if maybe_table_ref.map_or(true, |q| q == qualifier) {
                                     Some((maybe_table_ref.cloned(), Arc::clone(field)))
                                 } else {
                                     None

--- a/datafusion/physical-expr-common/src/sort_expr.rs
+++ b/datafusion/physical-expr-common/src/sort_expr.rs
@@ -172,11 +172,13 @@ impl PhysicalSortExpr {
         let nullable = self.expr.nullable(schema).unwrap_or(true);
         self.expr.eq(&requirement.expr)
             && if nullable {
-                requirement.options.is_none_or(|opts| self.options == opts)
+                requirement
+                    .options
+                    .map_or(true, |opts| self.options == opts)
             } else {
                 requirement
                     .options
-                    .is_none_or(|opts| self.options.descending == opts.descending)
+                    .map_or(true, |opts| self.options.descending == opts.descending)
             }
     }
 }
@@ -291,7 +293,7 @@ impl PhysicalSortRequirement {
         self.expr.eq(&other.expr)
             && other
                 .options
-                .is_none_or(|other_opts| self.options == Some(other_opts))
+                .map_or(true, |other_opts| self.options == Some(other_opts))
     }
 
     #[deprecated(since = "43.0.0", note = "use  LexRequirement::from_lex_ordering")]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -19,5 +19,5 @@
 # to compile this workspace and run CI jobs.
 
 [toolchain]
-channel = "1.85.0"
+channel = "1.84.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This reverts https://github.com/apache/datafusion/pull/14811, setting back the MSRV to 1.81.0