### PR TITLE
[branch-46] Fix is_none_or

### DIFF
--- a/datafusion/physical-expr/src/equivalence/properties/mod.rs
+++ b/datafusion/physical-expr/src/equivalence/properties/mod.rs
@@ -647,7 +647,7 @@ impl EquivalenceProperties {
                         req.expr.eq(&existing.expr)
                             && req
                                 .options
-                                .is_none_or(|req_opts| req_opts == existing.options)
+                                .map_or(true, |req_opts| req_opts == existing.options)
                     },
                 )
         })


### PR DESCRIPTION
This `is_none_or` method is not available on rust 1.81.0, and it seems like this was not reverted in https://github.com/DataDog/datafusion/pull/10 as probably it belongs to a later commit