### PR TITLE
[branch-48] downgrade sha2

### DIFF
--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -80,7 +80,7 @@ log = { workspace = true }
 md-5 = { version = "^0.10.0", optional = true }
 rand = { workspace = true }
 regex = { workspace = true, optional = true }
-sha2 = { version = "^0.10.9", optional = true }
+sha2 = { version = "^0.10.8", optional = true }
 unicode-segmentation = { version = "^1.7.1", optional = true }
 uuid = { version = "1.17", features = ["v4"], optional = true }
 


### PR DESCRIPTION
Because of certain incompatibilities, this needs to be downgraded