### PR TITLE
Revert "Bump the MSRV due to transitive dependencies (#16728)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/apache/datafusion"
 # Define Minimum Supported Rust Version (MSRV)
-rust-version = "1.85.1"
+rust-version = "1.82.0"
 # Define DataFusion version
 version = "49.0.0"
 


### PR DESCRIPTION
This reverts commit bd8fd295e672d1b5dbdca3027ca6be589a0fcbd5.

