### PR TITLE
[branch-50] Make datafusion-datasource not depend on default features 

### DIFF
--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -46,7 +46,17 @@ avro = ["datafusion/avro", "datafusion-common/avro"]
 [dependencies]
 arrow = { workspace = true }
 chrono = { workspace = true }
-datafusion = { workspace = true, default-features = true }
+datafusion = { workspace = true, default-features = false, features = [
+    "array_expressions",
+    "nested_expressions",
+    "datetime_expressions",
+    "encoding_expressions",
+    "regex_expressions",
+    "string_expressions",
+    "unicode_expressions",
+    "crypto_expressions",
+    "parquet",
+] }
 datafusion-common = { workspace = true, default-features = true }
 datafusion-expr = { workspace = true }
 datafusion-proto-common = { workspace = true }


### PR DESCRIPTION
Cherry picks [Make datafusion-proto not depend on datafusion's default features](https://github.com/DataDog/datafusion/pull/47)