### PR TITLE
[branch-50] Set update = none for datafusion-testing git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,4 @@
 	path = datafusion-testing
 	url = https://github.com/apache/datafusion-testing.git
 	branch = main
+	update = none

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -2378,7 +2378,7 @@ impl ScalarValue {
                 Arc::new(array)
             }
             // explicitly enumerate unsupported types so newly added
-            // types must be aknowledged, Time32 and Time64 types are
+            // types must be acknowledged, Time32 and Time64 types are
             // not supported if the TimeUnit is not valid (Time32 can
             // only be used with Second and Millisecond, Time64 only
             // with Microsecond and Nanosecond)

--- a/datafusion/core/src/datasource/listing/table.rs
+++ b/datafusion/core/src/datasource/listing/table.rs
@@ -1131,7 +1131,7 @@ impl ListingTable {
     }
 }
 
-// Expressions can be used for parttion pruning if they can be evaluated using
+// Expressions can be used for partition pruning if they can be evaluated using
 // only the partition columns and there are partition columns.
 fn can_be_evaluated_for_partition_pruning(
     partition_column_names: &[&str],

--- a/datafusion/core/tests/physical_optimizer/filter_pushdown/mod.rs
+++ b/datafusion/core/tests/physical_optimizer/filter_pushdown/mod.rs
@@ -1102,7 +1102,7 @@ async fn test_hashjoin_dynamic_filter_pushdown_partitioned() {
         Arc::new(CoalesceBatchesExec::new(hash_join, 8192)) as Arc<dyn ExecutionPlan>;
     // Top-level CoalescePartitionsExec
     let cp = Arc::new(CoalescePartitionsExec::new(cb)) as Arc<dyn ExecutionPlan>;
-    // Add a sort for determistic output
+    // Add a sort for deterministic output
     let plan = Arc::new(SortExec::new(
         LexOrdering::new(vec![PhysicalSortExpr::new(
             col("a", &probe_side_schema).unwrap(),

--- a/datafusion/physical-expr/src/expressions/case.rs
+++ b/datafusion/physical-expr/src/expressions/case.rs
@@ -1070,7 +1070,6 @@ mod tests {
         .into_iter()
         .collect();
 
-        //let valid_array = vec![true, false, false, true, false, tru
         let null_buffer = Buffer::from([0b00101001u8]);
         let load4 = load4
             .into_data()

--- a/docs/source/user-guide/introduction.md
+++ b/docs/source/user-guide/introduction.md
@@ -86,7 +86,7 @@ Here are some example systems built using DataFusion:
 By using DataFusion, projects are freed to focus on their specific
 features, and avoid reimplementing general (but still necessary)
 features such as an expression representation, standard optimizations,
-parellelized streaming execution plans, file format support, etc.
+parallelized streaming execution plans, file format support, etc.
 
 ## Known Users
 

--- a/typos.toml
+++ b/typos.toml
@@ -16,6 +16,7 @@ abov = "abov"
 Ois = "Ois"
 alo = "alo"
 Byt = "Byt"
+nteger = "nteger"
 
 # abbreviations, common words, etc.
 typ = "typ"


### PR DESCRIPTION
We've been seeing issues with some users in `dd-source` failing to be able to (via `cargo`) clone the `datafusion` repo due to `cargo` failing to clone the `datafusion-test` submodule. Let's make it so `cargo` doesn't try to do that.