### PR TITLE
[branch-52] Downgrade sha2 from 0.10.9 to 0.10.8

### DIFF
--- a/datafusion/functions/Cargo.toml
+++ b/datafusion/functions/Cargo.toml
@@ -85,7 +85,7 @@ md-5 = { version = "^0.10.0", optional = true }
 num-traits = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true, optional = true }
-sha2 = { version = "^0.10.9", optional = true }
+sha2 = { version = "^0.10.8", optional = true }
 unicode-segmentation = { version = "^1.7.1", optional = true }
 uuid = { version = "1.19", features = ["v4"], optional = true }
 


### PR DESCRIPTION
brings https://github.com/DataDog/datafusion/pull/29