### PR TITLE
[branch-52] Cherry-pick apache/datafusion#20533

### DIFF
--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -5032,12 +5032,17 @@ select cardinality(arrow_cast([[1, 2], [3, 4], [5, 6]], 'FixedSizeList(3, List(I
 query II
 select cardinality(make_array()), cardinality(make_array(make_array()))
 ----
-NULL 0
+0 0
+
+query II
+select cardinality([]), cardinality([]::int[]) as with_cast
+----
+0 0
 
 query II
 select cardinality(arrow_cast(make_array(), 'LargeList(Int64)')), cardinality(arrow_cast(make_array(make_array()), 'LargeList(List(Int64))'))
 ----
-NULL 0
+0 0
 
 #TODO
 #https://github.com/apache/datafusion/issues/9158
@@ -5045,6 +5050,12 @@ NULL 0
 #select cardinality(arrow_cast(make_array(), 'FixedSizeList(1, Null)')), cardinality(arrow_cast(make_array(make_array()), 'FixedSizeList(1, List(Int64))'))
 #----
 #NULL 0
+
+# cardinality of NULL arrays should return NULL
+query II
+select cardinality(NULL), cardinality(arrow_cast(NULL, 'LargeList(Int64)'))
+----
+NULL NULL
 
 # cardinality with columns
 query III


### PR DESCRIPTION
cherry-picks apache/datafusion#20533

necessary to cherry pick in https://github.com/DataDog/datafusion/pull/95 which has a fix for `string_to_array`