### PR TITLE
[branch-53] fix: string_to_array('', delim) returns empty array for PostgreSQL compatibility (#21104)

### DIFF
--- a/datafusion/functions-nested/src/string.rs
+++ b/datafusion/functions-nested/src/string.rs
@@ -735,31 +735,31 @@ where
     let mut list_builder = ListBuilder::new(string_builder);
 
     match null_value_array {
-        None => {
-            string_array.iter().zip(delimiter_array.iter()).for_each(
-                |(string, delimiter)| {
-                    match (string, delimiter) {
-                        (Some(string), Some("")) => {
-                            list_builder.values().append_value(string);
-                            list_builder.append(true);
-                        }
-                        (Some(string), Some(delimiter)) => {
-                            string.split(delimiter).for_each(|s| {
-                                list_builder.values().append_value(s);
-                            });
-                            list_builder.append(true);
-                        }
-                        (Some(string), None) => {
-                            string.chars().map(|c| c.to_string()).for_each(|c| {
-                                list_builder.values().append_value(c.as_str());
-                            });
-                            list_builder.append(true);
-                        }
-                        _ => list_builder.append(false), // null value
+        None => string_array.iter().zip(delimiter_array.iter()).for_each(
+            |(string, delimiter)| match (string, delimiter) {
+                (Some(string), Some("")) => {
+                    if !string.is_empty() {
+                        list_builder.values().append_value(string);
                     }
-                },
-            )
-        }
+                    list_builder.append(true);
+                }
+                (Some(string), Some(delimiter)) => {
+                    if !string.is_empty() {
+                        string.split(delimiter).for_each(|s| {
+                            list_builder.values().append_value(s);
+                        });
+                    }
+                    list_builder.append(true);
+                }
+                (Some(string), None) => {
+                    string.chars().map(|c| c.to_string()).for_each(|c| {
+                        list_builder.values().append_value(c.as_str());
+                    });
+                    list_builder.append(true);
+                }
+                _ => list_builder.append(false),
+            },
+        ),
         Some(null_value_array) => string_array
             .iter()
             .zip(delimiter_array.iter())
@@ -767,21 +767,25 @@ where
             .for_each(|((string, delimiter), null_value)| {
                 match (string, delimiter) {
                     (Some(string), Some("")) => {
-                        if Some(string) == null_value {
-                            list_builder.values().append_null();
-                        } else {
-                            list_builder.values().append_value(string);
+                        if !string.is_empty() {
+                            if Some(string) == null_value {
+                                list_builder.values().append_null();
+                            } else {
+                                list_builder.values().append_value(string);
+                            }
                         }
                         list_builder.append(true);
                     }
                     (Some(string), Some(delimiter)) => {
-                        string.split(delimiter).for_each(|s| {
-                            if Some(s) == null_value {
-                                list_builder.values().append_null();
-                            } else {
-                                list_builder.values().append_value(s);
-                            }
-                        });
+                        if !string.is_empty() {
+                            string.split(delimiter).for_each(|s| {
+                                if Some(s) == null_value {
+                                    list_builder.values().append_null();
+                                } else {
+                                    list_builder.values().append_value(s);
+                                }
+                            });
+                        }
                         list_builder.append(true);
                     }
                     (Some(string), None) => {

--- a/datafusion/sqllogictest/test_files/array.slt
+++ b/datafusion/sqllogictest/test_files/array.slt
@@ -8699,6 +8699,26 @@ SELECT string_to_array('abcxxxdef', 'xxx')
 ----
 [abc, def]
 
+query I
+SELECT cardinality(string_to_array('', ','))
+----
+0
+
+query I
+SELECT cardinality(string_to_array('', ''))
+----
+0
+
+query I
+SELECT cardinality(string_to_array('', ',', 'x'))
+----
+0
+
+query I
+SELECT cardinality(string_to_array('', '', 'x'))
+----
+0
+
 query ?
 SELECT string_to_array('abc', '')
 ----


### PR DESCRIPTION
Cherry picks https://github.com/apache/datafusion/pull/21104