### PR TITLE
Propagate BufferExec input panics instead of silently truncating output

### DIFF
--- a/datafusion/physical-plan/src/buffer.rs
+++ b/datafusion/physical-plan/src/buffer.rs
@@ -40,10 +40,11 @@ use datafusion_physical_expr_common::metrics::{
 };
 use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
 use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
-use futures::{Stream, StreamExt, TryStreamExt};
+use futures::{FutureExt, Stream, StreamExt, TryStreamExt};
 use pin_project_lite::pin_project;
 use std::any::Any;
 use std::fmt;
+use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -337,11 +338,24 @@ impl<T: Send + SizedMessage + 'static> MemoryBufferedStream<T> {
                 let item_or_err = tokio::select! {
                     biased;
                     _ = batch_tx.closed() => break,
-                    item_or_err = input.next() => {
-                        let Some(item_or_err) = item_or_err else {
-                            break; // stream finished
-                        };
-                        item_or_err
+                    // Catch a panic in the input poll so it surfaces as a stream error
+                    // instead of dropping `batch_tx` and looking like a clean EOF.
+                    polled = AssertUnwindSafe(input.next()).catch_unwind() => {
+                        match polled {
+                            Ok(Some(item_or_err)) => item_or_err,
+                            Ok(None) => break, // stream finished
+                            Err(panic) => {
+                                let msg = panic
+                                    .downcast_ref::<&str>()
+                                    .map(|s| s.to_string())
+                                    .or_else(|| panic.downcast_ref::<String>().cloned())
+                                    .unwrap_or_else(|| "unknown panic".to_string());
+                                let _ = batch_tx.send(internal_err!(
+                                    "BufferExec input stream panicked: {msg}"
+                                ));
+                                break;
+                            }
+                        }
                     }
                 };
 
@@ -551,6 +565,29 @@ mod tests {
         pull_ok_msg(&mut buffered).await?;
         pull_ok_msg(&mut buffered).await?;
         pull_err_msg(&mut buffered).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn panic_in_input_is_propagated() -> Result<(), Box<dyn Error>> {
+        // Panic mid-stream, modelling a panic deeper in the plan.
+        let input = futures::stream::iter([1, 2, 3, 4]).map(|v| {
+            if v == 3 {
+                panic!("boom on 3");
+            }
+            Ok(v)
+        });
+        let (_, res) = memory_pool_and_reservation();
+
+        let mut buffered = MemoryBufferedStream::new(input, 10, res);
+        wait_for_buffering().await;
+
+        pull_ok_msg(&mut buffered).await?;
+        pull_ok_msg(&mut buffered).await?;
+        // The panic is caught and surfaced as a stream error instead of a silent EOF.
+        let err = pull_err_msg(&mut buffered).await?;
+        assert_contains!(err.to_string(), "panicked");
 
         Ok(())
     }


### PR DESCRIPTION
## What

`MemoryBufferedStream` (the stream behind `BufferExec`) spawns a producer task that polls the input and feeds a channel. If a panic unwinds out of the input poll, the tokio task harness catches it, the sender drops, and the consumer reads the closed channel as a **clean EOF** — so the partition's output is **silently truncated** and the query "succeeds" with partial results.

This wraps the input poll in `catch_unwind` and forwards the panic as a `DataFusionError` over the existing error channel (`poll_next` already surfaces `Some(Err(..))`). The query now fails loudly instead of returning a wrong answer, and only the offending query fails (not the process).

## Why

Found in staging: a `SinglePartitioned` aggregate (`gby=[__bhandle__, date_bin]`) emitted a 16-byte `FixedSizeBinary` group-key column for ~458M groups — past Arrow's 2 GiB `i32`-offset limit — and panicked in `GroupValuesRows::emit`. The panic was swallowed here, so the query returned under-counted results instead of erroring.

The oversized emit itself is a separate, upstream-shaped fix (chunk the aggregate emit to `batch_size` so a single group-key array can't exceed 2 GiB). This PR only stops the **silent** failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
