### PR TITLE
[branch-54] Avoid sort pushdown panic on incomplete file statistics

### DIFF
--- a/datafusion/datasource/src/file_scan_config/mod.rs
+++ b/datafusion/datasource/src/file_scan_config/mod.rs
@@ -2592,6 +2592,16 @@ mod tests {
         ))
     }
 
+    fn make_file_with_empty_column_stats(name: &str) -> PartitionedFile {
+        PartitionedFile::new(name.to_string(), 1024).with_statistics(Arc::new(
+            Statistics {
+                num_rows: Precision::Absent,
+                total_byte_size: Precision::Absent,
+                column_statistics: vec![],
+            },
+        ))
+    }
+
     #[derive(Clone)]
     struct ExactSortPushdownSource {
         metrics: ExecutionPlanMetricsSet,
@@ -2950,6 +2960,32 @@ mod tests {
         let files1 = pushed_config.file_groups[1].files();
         assert_eq!(files1[0].object_meta.location.as_ref(), "file_d");
         assert_eq!(files1[1].object_meta.location.as_ref(), "file_c");
+        Ok(())
+    }
+
+    #[test]
+    fn sort_pushdown_unsupported_source_empty_column_statistics() -> Result<()> {
+        let file_schema =
+            Arc::new(Schema::new(vec![Field::new("a", DataType::Float64, false)]));
+        let table_schema = TableSchema::new(Arc::clone(&file_schema), vec![]);
+        let file_source = Arc::new(MockSource::new(table_schema));
+
+        let file_groups = vec![FileGroup::new(vec![
+            make_file_with_empty_column_stats("file_b"),
+            make_file_with_empty_column_stats("file_a"),
+        ])];
+
+        let sort_expr = PhysicalSortExpr::new_default(Arc::new(Column::new("a", 0)));
+        let config =
+            FileScanConfigBuilder::new(ObjectStoreUrl::local_filesystem(), file_source)
+                .with_file_groups(file_groups)
+                .build();
+
+        let result = config.try_pushdown_sort(&[sort_expr])?;
+        assert!(
+            matches!(result, SortOrderPushdownResult::Unsupported),
+            "expected missing file statistics to skip sort pushdown"
+        );
         Ok(())
     }
 

--- a/datafusion/datasource/src/statistics.rs
+++ b/datafusion/datasource/src/statistics.rs
@@ -97,7 +97,10 @@ impl MinMaxStatistics {
                             .zip(s.column_statistics[i].max_value.get_value().cloned())
                             .ok_or_else(|| plan_datafusion_err!("statistics not found"))
                     } else {
-                        let partition_value = &pv[i - s.column_statistics.len()];
+                        let Some(partition_value) = pv.get(i - s.column_statistics.len())
+                        else {
+                            return Err(plan_datafusion_err!("statistics not found"));
+                        };
                         Ok((partition_value.clone(), partition_value.clone()))
                     }
                 })
@@ -623,6 +626,44 @@ mod tests {
     fn file_with_stats(path: &str, stats: Statistics) -> PartitionedFile {
         PartitionedFile::new(path, 1).with_statistics(Arc::new(stats))
     }
+
+    fn file_with_empty_column_stats(path: &str) -> PartitionedFile {
+        PartitionedFile::new(path, 1).with_statistics(Arc::new(Statistics {
+            num_rows: Precision::Absent,
+            total_byte_size: Precision::Absent,
+            column_statistics: vec![],
+        }))
+    }
+
+    #[test]
+    fn min_max_statistics_errors_when_column_and_partition_stats_are_missing() {
+        let schema =
+            Arc::new(Schema::new(vec![Field::new("a", DataType::Float64, true)]));
+        let sort_order = LexOrdering::new(vec![PhysicalSortExpr::new_default(Arc::new(
+            Column::new("a", 0),
+        ))])
+        .unwrap();
+        let files = vec![
+            file_with_empty_column_stats("first.parquet"),
+            file_with_empty_column_stats("second.parquet"),
+        ];
+
+        let err = match MinMaxStatistics::new_from_files(
+            &sort_order,
+            &schema,
+            None,
+            files.iter(),
+        ) {
+            Ok(_) => panic!("expected missing statistics to return an error"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string().contains("statistics not found"),
+            "unexpected error: {err}"
+        );
+    }
+
     #[tokio::test]
     #[expect(deprecated)]
     async fn test_get_statistics_with_limit_casts_first_file_sum_to_sum_type()


### PR DESCRIPTION
## Problem

DF54 added a sort-pushdown fallback that tries to reorder files within each file group by min/max statistics. This is an optional optimization: if the files do not have usable stats, planning should keep the original file order and leave the normal `SortExec` in place.

One path did not handle incomplete file stats safely.

`MinMaxStatistics::new_from_files()` first looks for min/max in `file.statistics.column_statistics`. If the requested column index is past that vector, it assumes the value must be a partition column and reads `file.partition_values[...]`.

That assumption is not always true. A file can have a statistics object with no column statistics and also have no partition values.

Simplified failure:

```text
requested sort column: a@0

file.statistics.column_statistics: []
file.partition_values: []

current code:
  column 0 is not in column_statistics
  so read partition_values[0]
  but partition_values is empty
  panic: index out of bounds
```

Observed production stack:

```text
PushdownSort::optimize
  DataSourceExec::try_pushdown_sort
    FileScanConfig::try_sort_file_groups_by_statistics
      sort_files_within_groups_by_statistics
        MinMaxStatistics::new_from_files
          statistics.rs: pv[i - column_statistics.len()]
```

This surfaced on `df-executor-canary` while planning BlobStore parquet scans for `idp-shadow` `ListEntities` requests. The failing query shape sorted service names by `LOWER(name)` with pagination. This is not response-cache related: the trace had `cache_aware_planning=false` and `connectors_used=[blob]`.

## Patch

- Bounds-check the partition-value lookup in `MinMaxStatistics::new_from_files()`.
- Return the existing `statistics not found` planning signal when neither column stats nor partition values contain the requested stat.
- Keep the caller behavior unchanged: `sort_files_within_groups_by_statistics()` already catches missing-stat errors, keeps the original file group order, and skips the optional pushdown.

In other words, this does not turn the panic into a user-visible planning error. It makes the optional optimization gracefully decline:

```text
stats available:
  reorder files by min/max

stats unavailable:
  keep original file order
  keep SortExec
  query still plans normally
```

## Why this belongs in DataFusion

The invalid assumption is in the shared file-statistics helper, not in a Datadog connector. A dd-source-only mitigation, such as forcing BlobStore scans to collect parquet footer stats, would add planning I/O and only cover one caller. The helper should be robust whenever file statistics are incomplete.

## Tests

- [x] `cargo test -p datafusion-datasource min_max_statistics_errors_when_column_and_partition_stats_are_missing`
- [x] `cargo test -p datafusion-datasource sort_pushdown_unsupported_source_empty_column_statistics`

## References

- Datadog trace: https://app.datadoghq.com/apm/trace/5724981991073414002?graphType=flamegraph&shouldShowLegend=true&spanID=3283904308320907482&timeHint=1783001047000.0000&trace=57249819910734140023283904308320907482&traceQuery=
- Upstream activation commit: `cdfade51a feat: sort file groups by statistics during sort pushdown (Sort pushdown phase 2) (#21182)`