### PR TITLE
Cherry-pick apache/datafusion#22744 and #23312

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
+checksum = "b952ca5a8046ad741b60f142d6eca4aeebcad615694202bc64c5341f23e32c5b"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
+checksum = "64a13b8d3008c4e9063c597a08f46446fe3fd5789277127672d6c0bdbb43b1ff"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
+checksum = "9486151b2f0785bafc6fa04fc5c99fcb4495455662e58787ea32eaaed33c4192"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-avro"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "049230728cd6e093088c8d231b4beede184e35cad7777c1505c0d5a8571f4376"
+checksum = "2e4f9b23a0d7b613acb59fa20bdbe0f80ffdae6411498378340b3915e45f5b84"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
+checksum = "c4776577a87794bfdf0b4e90e2ea12454fa7738ea2823c4be5b9d1851da7b434"
 dependencies = [
  "bytes",
  "half",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
+checksum = "a9ad451ce4f98710828a455b96991b8f031deb2e67f5fcad6773f017e4a69c3a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de"
+checksum = "8aa7bf96d6141a7bcca2eed57c7c9767d2a2175281857b8a7b68308992864784"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
+checksum = "b38fe43e2e8704360f1464e6e8cc4fc381ef02cc4fb0192afa8df1aaa0115c66"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28abfe8bf9f124e5fc83b334af4fa58f8d0323ad25312ccb2d1da50178415704"
+checksum = "42115e09dbb694b5955da998912121451c6910b338228cb80a5701370dba43ff"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
+checksum = "29dac499fcbc6ba74ee0324057821d381929a48526a3966bd9dffb44aa06d98c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b"
+checksum = "0fe05e916ddc50f4c7a363cd69c0ef5894fcee063517e9a0b8582f0c56746af6"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
+checksum = "0e13dbdc2a9c053c10c7baa6e30faee04a180aa7ce88e471835850ce37abd20b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
+checksum = "4d5a1f8c733d15260b305683472ee8ad89c62cbd706703ca873b90d051b41592"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
+checksum = "d9e4969dc350d571766247143ab36a5187d095d3d3690970408bc630d47c69e5"
 dependencies = [
  "bitflags",
  "serde",
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
+checksum = "402770dba90865359d98d1ef92ef16e23d75c0cca9c2c880c8a05468b7743bf9"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -418,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
+checksum = "a2b0afbb8b9016700938291123df30838b89decc3213dba00852021988b170d3"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3688,12 +3688,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4347,15 +4341,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4402,9 +4387,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
+checksum = "5302d4da74d6596a1f11f9928767995b53bca657cbeea1e4e8c5074f8a1157dd"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -4431,7 +4416,6 @@ dependencies = [
  "seq-macro",
  "simdutf8",
  "snap",
- "thrift",
  "tokio",
  "twox-hash",
  "zstd",
@@ -6111,17 +6095,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "ordered-float",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,30 +88,30 @@ version = "54.0.0"
 #
 # See for more details: https://github.com/rust-lang/cargo/issues/11329
 apache-avro = { version = "0.21", default-features = false }
-arrow = { version = "58.3.0", features = [
+arrow = { version = "59.1.0", features = [
     "prettyprint",
     "chrono-tz",
 ] }
-arrow-avro = { version = "58.3.0", default-features = false, features = [
+arrow-avro = { version = "59.1.0", default-features = false, features = [
     "deflate",
     "snappy",
     "zstd",
     "bzip2",
     "xz",
 ] }
-arrow-buffer = { version = "58.3.0", default-features = false }
-arrow-data = { version = "58.3.0", default-features = false }
-arrow-flight = { version = "58.3.0", features = [
+arrow-buffer = { version = "59.1.0", default-features = false }
+arrow-data = { version = "59.1.0", default-features = false }
+arrow-flight = { version = "59.1.0", features = [
     "flight-sql-experimental",
 ] }
 # Both codecs are required here to make sure that code paths like
 # file-spilling have access to all compression codecs.
-arrow-ipc = { version = "58.3.0", default-features = false, features = [
+arrow-ipc = { version = "59.1.0", default-features = false, features = [
     "lz4",
     "zstd",
 ] }
-arrow-ord = { version = "58.3.0", default-features = false }
-arrow-schema = { version = "58.3.0", default-features = false }
+arrow-ord = { version = "59.1.0", default-features = false }
+arrow-schema = { version = "59.1.0", default-features = false }
 async-trait = "0.1.89"
 bigdecimal = "0.4.8"
 bytes = "1.11"
@@ -176,7 +176,7 @@ memchr = "2.8.0"
 num-traits = { version = "0.2" }
 object_store = { version = "0.13.2", default-features = false }
 parking_lot = "0.12"
-parquet = { version = "58.3.0", default-features = false, features = [
+parquet = { version = "59.1.0", default-features = false, features = [
     "arrow",
     "async",
     "object_store",

--- a/datafusion-cli/src/main.rs
+++ b/datafusion-cli/src/main.rs
@@ -613,9 +613,9 @@ mod tests {
         +-----------------------------------+-----------------+---------------------+------+------------------+
         | filename                          | file_size_bytes | metadata_size_bytes | hits | extra            |
         +-----------------------------------+-----------------+---------------------+------+------------------+
-        | alltypes_plain.parquet            | 1851            | 8882                | 2    | page_index=false |
-        | alltypes_tiny_pages.parquet       | 454233          | 269074              | 2    | page_index=true  |
-        | lz4_raw_compressed_larger.parquet | 380836          | 1339                | 2    | page_index=false |
+        | alltypes_plain.parquet            | 1851            | 8794                | 2    | page_index=false |
+        | alltypes_tiny_pages.parquet       | 454233          | 268970              | 2    | page_index=true  |
+        | lz4_raw_compressed_larger.parquet | 380836          | 1331                | 2    | page_index=false |
         +-----------------------------------+-----------------+---------------------+------+------------------+
         ");
 
@@ -644,9 +644,9 @@ mod tests {
         +-----------------------------------+-----------------+---------------------+------+------------------+
         | filename                          | file_size_bytes | metadata_size_bytes | hits | extra            |
         +-----------------------------------+-----------------+---------------------+------+------------------+
-        | alltypes_plain.parquet            | 1851            | 8882                | 5    | page_index=false |
-        | alltypes_tiny_pages.parquet       | 454233          | 269074              | 2    | page_index=true  |
-        | lz4_raw_compressed_larger.parquet | 380836          | 1339                | 3    | page_index=false |
+        | alltypes_plain.parquet            | 1851            | 8794                | 5    | page_index=false |
+        | alltypes_tiny_pages.parquet       | 454233          | 268970              | 2    | page_index=true  |
+        | lz4_raw_compressed_larger.parquet | 380836          | 1331                | 3    | page_index=false |
         +-----------------------------------+-----------------+---------------------+------+------------------+
         ");
 

--- a/datafusion-examples/examples/flight/server.rs
+++ b/datafusion-examples/examples/flight/server.rs
@@ -19,7 +19,7 @@
 
 use std::sync::Arc;
 
-use arrow::ipc::writer::{CompressionContext, DictionaryTracker, IpcDataGenerator};
+use arrow::ipc::writer::{DictionaryTracker, IpcDataGenerator, IpcWriteContext};
 use arrow_flight::{
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
     HandshakeRequest, HandshakeResponse, PutResult, SchemaResult, Ticket,
@@ -112,7 +112,7 @@ impl FlightService for FlightServiceImpl {
 
                 // add an initial FlightData message that sends schema
                 let options = arrow::ipc::writer::IpcWriteOptions::default();
-                let mut compression_context = CompressionContext::default();
+                let mut compression_context = IpcWriteContext::default();
                 let schema_flight_data = SchemaAsIpc::new(&schema, &options);
 
                 let mut flights = vec![FlightData::from(schema_flight_data)];

--- a/datafusion/common/src/file_options/mod.rs
+++ b/datafusion/common/src/file_options/mod.rs
@@ -114,14 +114,14 @@ mod tests {
             properties
                 .bloom_filter_properties(&ColumnPath::from(""))
                 .expect("expected bloom properties!")
-                .fpp,
+                .fpp(),
             0.123
         );
         assert_eq!(
             properties
                 .bloom_filter_properties(&ColumnPath::from(""))
                 .expect("expected bloom properties!")
-                .ndv,
+                .ndv(),
             123
         );
 
@@ -242,7 +242,7 @@ mod tests {
             properties
                 .bloom_filter_properties(&col1)
                 .expect("expected bloom properties!")
-                .fpp,
+                .fpp(),
             0.123
         );
 
@@ -250,7 +250,7 @@ mod tests {
             properties
                 .bloom_filter_properties(&col2_nested)
                 .expect("expected bloom properties!")
-                .fpp,
+                .fpp(),
             0.456
         );
 
@@ -258,7 +258,7 @@ mod tests {
             properties
                 .bloom_filter_properties(&col1)
                 .expect("expected bloom properties!")
-                .ndv,
+                .ndv(),
             123
         );
 
@@ -266,7 +266,7 @@ mod tests {
             properties
                 .bloom_filter_properties(&col2_nested)
                 .expect("expected bloom properties!")
-                .ndv,
+                .ndv(),
             456
         );
 

--- a/datafusion/common/src/file_options/parquet_writer.rs
+++ b/datafusion/common/src/file_options/parquet_writer.rs
@@ -157,8 +157,8 @@ impl TryFrom<&TableParquetOptions> for WriterPropertiesBuilder {
             }
 
             if let Some(bloom_filter_ndv) = options.bloom_filter_ndv {
-                builder =
-                    builder.set_column_bloom_filter_ndv(path.clone(), bloom_filter_ndv);
+                builder = builder
+                    .set_column_bloom_filter_max_ndv(path.clone(), bloom_filter_ndv);
             }
         }
 
@@ -271,7 +271,7 @@ impl ParquetOptions {
             builder = builder.set_bloom_filter_fpp(*bloom_filter_fpp);
         };
         if let Some(bloom_filter_ndv) = bloom_filter_ndv {
-            builder = builder.set_bloom_filter_ndv(*bloom_filter_ndv);
+            builder = builder.set_bloom_filter_max_ndv(*bloom_filter_ndv);
         };
         if let Some(dictionary_enabled) = dictionary_enabled {
             builder = builder.set_dictionary_enabled(*dictionary_enabled);
@@ -530,8 +530,8 @@ mod tests {
                 }
                 .into(),
             ),
-            bloom_filter_fpp: bloom_filter_default_props.map(|p| p.fpp),
-            bloom_filter_ndv: bloom_filter_default_props.map(|p| p.ndv),
+            bloom_filter_fpp: bloom_filter_default_props.map(|p| p.fpp()),
+            bloom_filter_ndv: bloom_filter_default_props.map(|p| p.ndv()),
         }
     }
 
@@ -823,10 +823,12 @@ mod tests {
         );
         assert_eq!(
             default_writer_props.bloom_filter_properties(&"default".into()),
-            Some(&BloomFilterProperties {
-                fpp: 0.42,
-                ndv: DEFAULT_BLOOM_FILTER_NDV
-            }),
+            Some(
+                &BloomFilterProperties::builder()
+                    .with_fpp(0.42)
+                    .with_max_ndv(DEFAULT_BLOOM_FILTER_NDV)
+                    .build()
+            ),
             "should have only the fpp set, and the ndv at default",
         );
     }
@@ -910,7 +912,7 @@ mod tests {
         // the WriterProperties::default, with only ndv set
         let default_writer_props = WriterProperties::builder()
             .set_bloom_filter_enabled(true)
-            .set_bloom_filter_ndv(42)
+            .set_bloom_filter_max_ndv(42)
             .build();
 
         assert_eq!(
@@ -920,10 +922,12 @@ mod tests {
         );
         assert_eq!(
             default_writer_props.bloom_filter_properties(&"default".into()),
-            Some(&BloomFilterProperties {
-                fpp: DEFAULT_BLOOM_FILTER_FPP,
-                ndv: 42
-            }),
+            Some(
+                &BloomFilterProperties::builder()
+                    .with_fpp(DEFAULT_BLOOM_FILTER_FPP)
+                    .with_max_ndv(42)
+                    .build()
+            ),
             "should have only the ndv set, and the fpp at default",
         );
     }

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -5132,7 +5132,8 @@ impl ScalarValue {
 /// as necessary.
 pub fn copy_array_data(src_data: &ArrayData) -> ArrayData {
     let mut copy = MutableArrayData::new(vec![&src_data], true, src_data.len());
-    copy.extend(0, 0, src_data.len());
+    copy.try_extend(0, 0, src_data.len())
+        .expect("copy_array_data failed due to offset overflow");
     copy.freeze()
 }
 

--- a/datafusion/common/src/utils/mod.rs
+++ b/datafusion/common/src/utils/mod.rs
@@ -1157,11 +1157,11 @@ fn truncate_list_nulls<O: OffsetSizeTrait>(
             let (valid_or_empty, _nulls) = valid_or_empty.into_parts();
 
             for (start, end) in valid_or_empty.set_slices() {
-                mutable_array_data.extend(
+                mutable_array_data.try_extend(
                     0,
                     offsets[start].as_usize(),
                     offsets[end].as_usize(),
-                );
+                )?;
             }
 
             let lengths = std::iter::zip(offsets.lengths(), nulls)

--- a/datafusion/core/tests/datasource/object_store_access.rs
+++ b/datafusion/core/tests/datasource/object_store_access.rs
@@ -904,7 +904,7 @@ async fn query_single_parquet_file_with_single_predicate() {
     RequestCountingObjectStore()
     Total Requests: 2
     - GET  (opts) path=parquet_table.parquet head=true
-    - GET  (ranges) path=parquet_table.parquet ranges=1064-1481,1481-1594,1594-2011,2011-2124
+    - GET  (ranges) path=parquet_table.parquet ranges=1064-1594,1594-2124
     "
     );
 }
@@ -928,8 +928,8 @@ async fn query_single_parquet_file_multi_row_groups_multiple_predicates() {
     RequestCountingObjectStore()
     Total Requests: 3
     - GET  (opts) path=parquet_table.parquet head=true
-    - GET  (ranges) path=parquet_table.parquet ranges=4-421,421-534,534-951,951-1064
-    - GET  (ranges) path=parquet_table.parquet ranges=1064-1481,1481-1594,1594-2011,2011-2124
+    - GET  (ranges) path=parquet_table.parquet ranges=4-534,534-1064
+    - GET  (ranges) path=parquet_table.parquet ranges=1064-1594,1594-2124
     "
     );
 }

--- a/datafusion/core/tests/extension_types/pretty_printing.rs
+++ b/datafusion/core/tests/extension_types/pretty_printing.rs
@@ -40,10 +40,16 @@ async fn create_test_table() -> Result<DataFrame> {
     // define data.
     let batch = RecordBatch::try_new(
         schema,
-        vec![Arc::new(FixedSizeBinaryArray::from(vec![
-            &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 5, 6],
-        ]))],
+        vec![Arc::new(
+            FixedSizeBinaryArray::try_from_iter(
+                vec![
+                    &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 5, 6],
+                ]
+                .into_iter(),
+            )
+            .unwrap(),
+        )],
     )?;
 
     let state = SessionStateBuilder::default()

--- a/datafusion/core/tests/parquet/mod.rs
+++ b/datafusion/core/tests/parquet/mod.rs
@@ -726,11 +726,11 @@ fn make_bytearray_batch(
     let name: StringArray = std::iter::repeat_n(Some(name), num_rows).collect();
     let service_string: StringArray = string_values.iter().map(Some).collect();
     let service_binary: BinaryArray = binary_values.iter().map(Some).collect();
-    let service_fixedsize: FixedSizeBinaryArray = fixedsize_values
-        .iter()
-        .map(|value| Some(value.as_slice()))
-        .collect::<Vec<_>>()
-        .into();
+    let service_fixedsize = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+        fixedsize_values.iter().map(|value| Some(value.as_slice())),
+        3,
+    )
+    .unwrap();
     let service_large_binary: LargeBinaryArray =
         large_binary_values.iter().map(Some).collect();
 

--- a/datafusion/datasource-parquet/src/row_group_filter.rs
+++ b/datafusion/datasource-parquet/src/row_group_filter.rs
@@ -955,10 +955,7 @@ mod tests {
         let schema =
             Arc::new(Schema::new(vec![Field::new("c1", Decimal128(9, 2), false)]));
         let field = PrimitiveTypeField::new("c1", PhysicalType::INT32)
-            .with_logical_type(LogicalType::Decimal {
-                scale: 2,
-                precision: 9,
-            })
+            .with_logical_type(LogicalType::decimal(2, 9))
             .with_scale(2)
             .with_precision(9);
         let schema_descr = get_test_schema_descr(vec![field]);
@@ -1023,10 +1020,7 @@ mod tests {
             Arc::new(Schema::new(vec![Field::new("c1", Decimal128(9, 0), false)]));
 
         let field = PrimitiveTypeField::new("c1", PhysicalType::INT32)
-            .with_logical_type(LogicalType::Decimal {
-                scale: 0,
-                precision: 9,
-            })
+            .with_logical_type(LogicalType::decimal(0, 9))
             .with_scale(0)
             .with_precision(9);
         let schema_descr = get_test_schema_descr(vec![field]);
@@ -1118,10 +1112,7 @@ mod tests {
             false,
         )]));
         let field = PrimitiveTypeField::new("c1", PhysicalType::INT64)
-            .with_logical_type(LogicalType::Decimal {
-                scale: 2,
-                precision: 18,
-            })
+            .with_logical_type(LogicalType::decimal(2, 18))
             .with_scale(2)
             .with_precision(18);
         let schema_descr = get_test_schema_descr(vec![field]);
@@ -1176,10 +1167,7 @@ mod tests {
             false,
         )]));
         let field = PrimitiveTypeField::new("c1", PhysicalType::FIXED_LEN_BYTE_ARRAY)
-            .with_logical_type(LogicalType::Decimal {
-                scale: 2,
-                precision: 18,
-            })
+            .with_logical_type(LogicalType::decimal(2, 18))
             .with_scale(2)
             .with_precision(18)
             .with_byte_len(16);
@@ -1254,10 +1242,7 @@ mod tests {
             false,
         )]));
         let field = PrimitiveTypeField::new("c1", PhysicalType::BYTE_ARRAY)
-            .with_logical_type(LogicalType::Decimal {
-                scale: 2,
-                precision: 18,
-            })
+            .with_logical_type(LogicalType::decimal(2, 18))
             .with_scale(2)
             .with_precision(18)
             .with_byte_len(16);

--- a/datafusion/functions-aggregate/src/min_max/min_max_struct.rs
+++ b/datafusion/functions-aggregate/src/min_max/min_max_struct.rs
@@ -116,7 +116,7 @@ impl GroupsAccumulator for MinMaxStructAccumulator {
         let mut copy = MutableArrayData::new(min_maxes_refs, true, min_maxes_data.len());
 
         for (i, item) in min_maxes_data.iter().enumerate() {
-            copy.extend(i, 0, item.len());
+            copy.try_extend(i, 0, item.len())?;
         }
         let result = copy.freeze();
         assert_eq!(&self.inner.data_type, result.data_type());

--- a/datafusion/functions-nested/src/array_compact.rs
+++ b/datafusion/functions-nested/src/array_compact.rs
@@ -164,7 +164,7 @@ fn compact_list<O: OffsetSizeTrait>(
             if values.is_null(i) {
                 // Null breaks the current batch — flush it
                 if let Some(bs) = batch_start {
-                    mutable.extend(0, bs, i);
+                    mutable.try_extend(0, bs, i)?;
                     copied += i - bs;
                     batch_start = None;
                 }
@@ -174,7 +174,7 @@ fn compact_list<O: OffsetSizeTrait>(
         }
         // Flush any remaining batch after the loop
         if let Some(bs) = batch_start {
-            mutable.extend(0, bs, end);
+            mutable.try_extend(0, bs, end)?;
             copied += end - bs;
         }
 

--- a/datafusion/functions-nested/src/arrays_zip.rs
+++ b/datafusion/functions-nested/src/arrays_zip.rs
@@ -275,15 +275,15 @@ fn arrays_zip_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
                     let end = v.offsets[row_idx + 1];
                     let len = end - start;
                     let builder = builders[col_idx].as_mut().unwrap();
-                    builder.extend(0, start, end);
+                    builder.try_extend(0, start, end)?;
                     if len < max_len {
-                        builder.extend_nulls(max_len - len);
+                        builder.try_extend_nulls(max_len - len)?;
                     }
                 }
                 _ => {
                     // Null list entry or None (Null-typed) arg — all nulls.
                     if let Some(builder) = builders[col_idx].as_mut() {
-                        builder.extend_nulls(max_len);
+                        builder.try_extend_nulls(max_len)?;
                     }
                 }
             }

--- a/datafusion/functions-nested/src/concat.rs
+++ b/datafusion/functions-nested/src/concat.rs
@@ -432,7 +432,7 @@ fn concat_internal<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
             let start = list_array.offsets()[row_idx].to_usize().unwrap();
             let end = list_array.offsets()[row_idx + 1].to_usize().unwrap();
             if start < end {
-                mutable.extend(arr_idx, start, end);
+                mutable.try_extend(arr_idx, start, end)?;
             }
         }
         offsets.push(O::usize_as(mutable.len()));
@@ -553,11 +553,11 @@ where
         let start = offset_window[0].to_usize().unwrap();
         let end = offset_window[1].to_usize().unwrap();
         if is_append {
-            mutable.extend(values_index, start, end);
-            mutable.extend(element_index, row_index, row_index + 1);
+            mutable.try_extend(values_index, start, end)?;
+            mutable.try_extend(element_index, row_index, row_index + 1)?;
         } else {
-            mutable.extend(element_index, row_index, row_index + 1);
-            mutable.extend(values_index, start, end);
+            mutable.try_extend(element_index, row_index, row_index + 1)?;
+            mutable.try_extend(values_index, start, end)?;
         }
         offsets.push(offsets[row_index] + O::usize_as(end - start + 1));
     }

--- a/datafusion/functions-nested/src/extract.rs
+++ b/datafusion/functions-nested/src/extract.rs
@@ -258,7 +258,7 @@ where
 
         // array is null
         if array.is_null(row_index) {
-            mutable.extend_nulls(1);
+            mutable.try_extend_nulls(1)?;
             continue;
         }
 
@@ -266,10 +266,10 @@ where
 
         if let Some(index) = index {
             let start = start.as_usize() + index.as_usize();
-            mutable.extend(0, start, start + 1_usize);
+            mutable.try_extend(0, start, start + 1_usize)?;
         } else {
             // Index out of bounds
-            mutable.extend_nulls(1);
+            mutable.try_extend_nulls(1)?;
         }
     }
 
@@ -639,7 +639,7 @@ where
         let len = end - start;
 
         if nulls.as_ref().is_some_and(|n| n.is_null(row_index)) {
-            mutable.extend_nulls(1);
+            mutable.try_extend_nulls(1)?;
             offsets.push(offsets[row_index] + O::usize_as(1));
             continue;
         }
@@ -665,14 +665,14 @@ where
             } => {
                 let start_index = (start + rel_start).to_usize().unwrap();
                 let end_index = (start + rel_start + slice_len).to_usize().unwrap();
-                mutable.extend(0, start_index, end_index);
+                mutable.try_extend(0, start_index, end_index)?;
                 offsets.push(offsets[row_index] + slice_len);
             }
             SlicePlan::Indices(indices) => {
                 let count = indices.len();
                 for rel_index in indices {
                     let absolute_index = (start + rel_index).to_usize().unwrap();
-                    mutable.extend(0, absolute_index, absolute_index + 1);
+                    mutable.try_extend(0, absolute_index, absolute_index + 1)?;
                 }
                 offsets.push(offsets[row_index] + O::usize_as(count));
             }
@@ -754,7 +754,7 @@ where
             } => {
                 let start_index = (start + rel_start).to_usize().unwrap();
                 let end_index = (start + rel_start + slice_len).to_usize().unwrap();
-                mutable.extend(0, start_index, end_index);
+                mutable.try_extend(0, start_index, end_index)?;
                 offsets.push(current_offset);
                 sizes.push(slice_len);
                 current_offset += slice_len;
@@ -763,7 +763,7 @@ where
                 let count = indices.len();
                 for rel_index in indices {
                     let absolute_index = (start + rel_index).to_usize().unwrap();
-                    mutable.extend(0, absolute_index, absolute_index + 1);
+                    mutable.try_extend(0, absolute_index, absolute_index + 1)?;
                 }
                 let length = O::usize_as(count);
                 offsets.push(current_offset);
@@ -1065,7 +1065,7 @@ where
 
         // array is null
         if array.is_null(row_index) {
-            mutable.extend_nulls(1);
+            mutable.try_extend_nulls(1)?;
             continue;
         }
 
@@ -1077,16 +1077,16 @@ where
                     row_nulls_buffer.valid_indices().next()
                 {
                     let index = start.as_usize() + first_non_null_index;
-                    mutable.extend(0, index, index + 1)
+                    mutable.try_extend(0, index, index + 1)?;
                 } else {
                     // all the elements in the array are null
-                    mutable.extend_nulls(1);
+                    mutable.try_extend_nulls(1)?;
                 }
             }
             None => {
                 // no nulls are present in the array so take the first element
                 let index = start.as_usize();
-                mutable.extend(0, index, index + 1);
+                mutable.try_extend(0, index, index + 1)?;
             }
         }
     }

--- a/datafusion/functions-nested/src/make_array.rs
+++ b/datafusion/functions-nested/src/make_array.rs
@@ -224,9 +224,9 @@ pub fn array_array<O: OffsetSizeTrait>(
                 && !arg.is_null(row_idx)
                 && arg.is_valid(row_idx)
             {
-                mutable.extend(arr_idx, row_idx, row_idx + 1);
+                mutable.try_extend(arr_idx, row_idx, row_idx + 1)?;
             } else {
-                mutable.extend_nulls(1);
+                mutable.try_extend_nulls(1)?;
             }
         }
         offsets.push(O::usize_as(mutable.len()));

--- a/datafusion/functions-nested/src/map_extract.rs
+++ b/datafusion/functions-nested/src/map_extract.rs
@@ -161,10 +161,10 @@ fn general_map_extract_inner(
 
         match value_index {
             Some(index) => {
-                mutable.extend(0, start + index, start + index + 1);
+                mutable.try_extend(0, start + index, start + index + 1)?;
             }
             None => {
-                mutable.extend_nulls(1);
+                mutable.try_extend_nulls(1)?;
             }
         }
         offsets.push(offsets[row_index] + 1);

--- a/datafusion/functions-nested/src/remove.rs
+++ b/datafusion/functions-nested/src/remove.rs
@@ -425,7 +425,7 @@ fn general_remove<OffsetSize: OffsetSizeTrait>(
 
         // Fast path: no elements to remove, copy entire row
         if num_to_remove == 0 {
-            mutable.extend(0, start, end);
+            mutable.try_extend(0, start, end)?;
             offsets.push(offsets[row_index] + OffsetSize::usize_as(end - start));
             continue;
         }
@@ -440,7 +440,7 @@ fn general_remove<OffsetSize: OffsetSizeTrait>(
             if keep == Some(false) && removed < max_removals {
                 // Flush pending batch before skipping this element
                 if let Some(bs) = pending_batch_to_retain {
-                    mutable.extend(0, start + bs, start + i);
+                    mutable.try_extend(0, start + bs, start + i)?;
                     copied += i - bs;
                     pending_batch_to_retain = None;
                 }
@@ -452,7 +452,7 @@ fn general_remove<OffsetSize: OffsetSizeTrait>(
 
         // Flush remaining batch
         if let Some(bs) = pending_batch_to_retain {
-            mutable.extend(0, start + bs, start + eq_array.len());
+            mutable.try_extend(0, start + bs, start + eq_array.len())?;
             copied += eq_array.len() - bs;
         }
 

--- a/datafusion/functions-nested/src/replace.rs
+++ b/datafusion/functions-nested/src/replace.rs
@@ -348,11 +348,11 @@ fn general_replace<O: OffsetSizeTrait>(
 
         // All elements are false, no need to replace, just copy original data
         if n <= 0 || !eq_array.has_true() {
-            mutable.extend(
+            mutable.try_extend(
                 original_idx.to_usize().unwrap(),
                 start.to_usize().unwrap(),
                 end.to_usize().unwrap(),
-            );
+            )?;
             offsets.push(offsets[row_index] + (end - start));
             valid.append_non_null();
             continue;
@@ -364,21 +364,25 @@ fn general_replace<O: OffsetSizeTrait>(
             if to_replace == Some(true) && counter < n {
                 // Flush any pending retain run before emitting the replacement.
                 if let Some(rs) = pending_retain.take() {
-                    mutable.extend(
+                    mutable.try_extend(
                         original_idx.to_usize().unwrap(),
                         (start + rs).to_usize().unwrap(),
                         (start + i).to_usize().unwrap(),
-                    );
+                    )?;
                 }
-                mutable.extend(replace_idx.to_usize().unwrap(), row_index, row_index + 1);
+                mutable.try_extend(
+                    replace_idx.to_usize().unwrap(),
+                    row_index,
+                    row_index + 1,
+                )?;
                 counter += 1;
                 if counter == n {
                     // copy original data for any matches past n
-                    mutable.extend(
+                    mutable.try_extend(
                         original_idx.to_usize().unwrap(),
                         (start + i).to_usize().unwrap() + 1,
                         end.to_usize().unwrap(),
-                    );
+                    )?;
                     break;
                 }
             } else if pending_retain.is_none() {
@@ -391,11 +395,11 @@ fn general_replace<O: OffsetSizeTrait>(
         if counter < n
             && let Some(rs) = pending_retain
         {
-            mutable.extend(
+            mutable.try_extend(
                 original_idx.to_usize().unwrap(),
                 (start + rs).to_usize().unwrap(),
                 end.to_usize().unwrap(),
-            );
+            )?;
         }
 
         offsets.push(offsets[row_index] + (end - start));

--- a/datafusion/functions-nested/src/resize.rs
+++ b/datafusion/functions-nested/src/resize.rs
@@ -256,7 +256,7 @@ fn general_list_resize<O: OffsetSizeTrait + TryInto<i64>>(
             &original_data,
             &default_value_data,
             output_values_len,
-            |mutable, _, extra_count| mutable.extend(1, 0, extra_count),
+            |mutable, _, extra_count| Ok(mutable.try_extend(1, 0, extra_count)?),
         )
     } else {
         // Slow path: rows may need different fill values, so append from the
@@ -278,8 +278,9 @@ fn general_list_resize<O: OffsetSizeTrait + TryInto<i64>>(
             output_values_len,
             |mutable, row_index, extra_count| {
                 for _ in 0..extra_count {
-                    mutable.extend(1, row_index, row_index + 1);
+                    mutable.try_extend(1, row_index, row_index + 1)?;
                 }
+                Ok(())
             },
         )
     }
@@ -296,7 +297,7 @@ fn build_resized_list<O, F>(
 ) -> Result<ArrayRef>
 where
     O: OffsetSizeTrait + TryInto<i64>,
-    F: FnMut(&mut MutableArrayData, usize, usize),
+    F: FnMut(&mut MutableArrayData, usize, usize) -> Result<()>,
 {
     let capacity = Capacities::Array(output_values_len);
     let mut offsets = vec![O::usize_as(0)];
@@ -323,11 +324,11 @@ where
         if start + count > offset_window[1] {
             let extra_count = (start + count - offset_window[1]).to_usize().unwrap();
             let end = offset_window[1];
-            mutable.extend(0, start.to_usize().unwrap(), end.to_usize().unwrap());
-            append_fill_values(&mut mutable, row_index, extra_count);
+            mutable.try_extend(0, start.to_usize().unwrap(), end.to_usize().unwrap())?;
+            append_fill_values(&mut mutable, row_index, extra_count)?;
         } else {
             let end = start + count;
-            mutable.extend(0, start.to_usize().unwrap(), end.to_usize().unwrap());
+            mutable.try_extend(0, start.to_usize().unwrap(), end.to_usize().unwrap())?;
         };
         offsets.push(offsets[row_index] + count);
     }

--- a/datafusion/functions/src/core/getfield.rs
+++ b/datafusion/functions/src/core/getfield.rs
@@ -137,11 +137,11 @@ fn process_map_array(
             .find(|(_, t)| t.unwrap());
 
         if maybe_matched.is_none() {
-            mutable.extend_nulls(1);
+            mutable.try_extend_nulls(1)?;
             continue;
         }
         let (match_offset, _) = maybe_matched.unwrap();
-        mutable.extend(0, start + match_offset, start + match_offset + 1);
+        mutable.try_extend(0, start + match_offset, start + match_offset + 1)?;
     }
 
     let data = mutable.freeze();
@@ -174,14 +174,14 @@ fn process_map_with_nested_key(
         let mut found_match = false;
         for i in start..end {
             if comparator(i, 0).is_eq() {
-                mutable.extend(0, i, i + 1);
+                mutable.try_extend(0, i, i + 1)?;
                 found_match = true;
                 break;
             }
         }
 
         if !found_match {
-            mutable.extend_nulls(1);
+            mutable.try_extend_nulls(1)?;
         }
     }
 

--- a/datafusion/physical-expr-common/src/utils.rs
+++ b/datafusion/physical-expr-common/src/utils.rs
@@ -370,21 +370,21 @@ fn scatter_fallback(
     let mut true_pos = 0;
 
     let mask_array = BooleanArray::new(mask.clone(), None);
-    SlicesIterator::new(&mask_array).for_each(|(start, end)| {
+    for (start, end) in SlicesIterator::new(&mask_array) {
         // the gap needs to be filled with nulls
         if start > filled {
-            mutable.extend_nulls(start - filled);
+            mutable.try_extend_nulls(start - filled)?;
         }
         // fill with truthy values
         let len = end - start;
-        mutable.extend(0, true_pos, true_pos + len);
+        mutable.try_extend(0, true_pos, true_pos + len)?;
         true_pos += len;
         filled = end;
-    });
+    }
 
     // the remaining part is falsy
     if filled < output_len {
-        mutable.extend_nulls(output_len - filled);
+        mutable.try_extend_nulls(output_len - filled)?;
     }
 
     let data = mutable.freeze();
@@ -614,11 +614,9 @@ mod tests {
 
     #[test]
     fn scatter_fixed_size_binary_test() -> Result<()> {
-        let truthy = Arc::new(FixedSizeBinaryArray::from(vec![
-            &[1u8, 2][..],
-            &[3, 4][..],
-            &[5, 6][..],
-        ]));
+        let truthy = Arc::new(FixedSizeBinaryArray::try_from_iter(
+            vec![&[1u8, 2][..], &[3, 4][..], &[5, 6][..]].into_iter(),
+        )?);
         let mask = BooleanArray::from(vec![true, false, true, false, true]);
 
         let result = scatter(&mask, truthy.as_ref())?;

--- a/datafusion/physical-expr/benches/in_list_strategy.rs
+++ b/datafusion/physical-expr/benches/in_list_strategy.rs
@@ -993,7 +993,7 @@ fn bench_fixed_size_binary_inner(
         .collect();
 
     let refs: Vec<&[u8]> = values.iter().map(|v| v.as_slice()).collect();
-    let array = FixedSizeBinaryArray::from(refs);
+    let array = FixedSizeBinaryArray::try_from_iter(refs.into_iter()).unwrap();
 
     let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), true)]);
     let exprs: Vec<_> = haystack

--- a/datafusion/physical-plan/src/joins/sort_merge_join/tests.rs
+++ b/datafusion/physical-plan/src/joins/sort_merge_join/tests.rs
@@ -175,7 +175,7 @@ fn build_fixed_size_binary_table(
     let batch = RecordBatch::try_new(
         Arc::new(schema),
         vec![
-            Arc::new(FixedSizeBinaryArray::from(a.1.clone())),
+            Arc::new(FixedSizeBinaryArray::try_from_iter(a.1.iter().copied()).unwrap()),
             Arc::new(Int32Array::from(b.1.clone())),
             Arc::new(Int32Array::from(c.1.clone())),
         ],

--- a/datafusion/proto-common/src/to_proto/mod.rs
+++ b/datafusion/proto-common/src/to_proto/mod.rs
@@ -29,7 +29,7 @@ use arrow::datatypes::{
     SchemaRef, TimeUnit, UnionMode,
 };
 use arrow::ipc::writer::{
-    CompressionContext, DictionaryTracker, IpcDataGenerator, IpcWriteOptions,
+    DictionaryTracker, IpcDataGenerator, IpcWriteContext, IpcWriteOptions,
 };
 use datafusion_common::parsers::CsvQuoteStyle;
 use datafusion_common::{
@@ -1111,7 +1111,7 @@ fn encode_scalar_nested_value(
         &mut dict_tracker,
         &write_options,
     );
-    let mut compression_context = CompressionContext::default();
+    let mut compression_context = IpcWriteContext::default();
     let (encoded_dictionaries, encoded_message) = ipc_gen
         .encode(
             &batch,

--- a/datafusion/spark/src/function/array/shuffle.rs
+++ b/datafusion/spark/src/function/array/shuffle.rs
@@ -185,7 +185,7 @@ fn general_array_shuffle<O: OffsetSizeTrait>(
         if array.is_null(row_index) {
             nulls.push(false);
             offsets.push(offsets[row_index] + O::one());
-            mutable.extend(0, 0, 1);
+            mutable.try_extend(0, 0, 1)?;
             continue;
         }
         nulls.push(true);
@@ -200,7 +200,7 @@ fn general_array_shuffle<O: OffsetSizeTrait>(
 
         // Add shuffled elements
         for &index in &indices {
-            mutable.extend(0, index, index + 1);
+            mutable.try_extend(0, index, index + 1)?;
         }
 
         offsets.push(offsets[row_index] + O::usize_as(length));
@@ -239,7 +239,7 @@ fn fixed_size_array_shuffle(
         // skip the null value
         if array.is_null(row_index) {
             nulls.push(false);
-            mutable.extend(0, 0, value_length);
+            mutable.try_extend(0, 0, value_length)?;
             continue;
         }
         nulls.push(true);
@@ -253,7 +253,7 @@ fn fixed_size_array_shuffle(
 
         // Add shuffled elements
         for &index in &indices {
-            mutable.extend(0, index, index + 1);
+            mutable.try_extend(0, index, index + 1)?;
         }
     }
 

--- a/datafusion/spark/src/function/hash/xxhash64.rs
+++ b/datafusion/spark/src/function/hash/xxhash64.rs
@@ -363,12 +363,17 @@ mod tests {
 
     #[test]
     fn test_xxhash64_fixed_size_binary() {
-        let array = FixedSizeBinaryArray::from(vec![
-            Some(&[0x01, 0x02, 0x03, 0x04][..]),
-            Some(&[0x05, 0x06, 0x07, 0x08][..]),
-            None,
-            Some(&[0x00, 0x00, 0x00, 0x00][..]),
-        ]);
+        let array = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+            vec![
+                Some(&[0x01, 0x02, 0x03, 0x04][..]),
+                Some(&[0x05, 0x06, 0x07, 0x08][..]),
+                None,
+                Some(&[0x00, 0x00, 0x00, 0x00][..]),
+            ]
+            .into_iter(),
+            4,
+        )
+        .unwrap();
         let array_ref: ArrayRef = Arc::new(array);
 
         let mut hashes = vec![DEFAULT_SEED; 4];


### PR DESCRIPTION
## Why

DataDog's DataFusion branch-54 uses Arrow and Parquet 58.3.0. apache/datafusion#23312 updates to 59.1.0 but depends on the 58.x-to-59.0 API migration in apache/datafusion#22744.

## What

Backport both upstream changes to branch-54. The branch updates Arrow and Parquet to 59.1.0 and adapts upstream and branch-54-specific call sites to Arrow/Parquet 59 APIs.

## How

The upstream squash commits were cherry-picked with their original SHAs recorded. Overlaps with branch-54-specific implementations retain branch behavior while applying the migration. Cargo.lock was regenerated from the branch-54 dependency graph.

Validation completed:
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets` with Rust 1.96
- 3,214 physical expression/plan and Spark tests passed, 2 ignored
- 13 focused Parquet decimal tests passed

Upstream:
- https://github.com/apache/datafusion/pull/22744
- https://github.com/apache/datafusion/pull/23312